### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1368,13 +1368,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz",
-      "integrity": "sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.38.0.tgz",
+      "integrity": "sha512-iZq5USgybUcj/lfnbuelJ0j3K9dbs1I3RICAJY9NZZpDgBYXmuUlYQGzftpQA9wC8cKgtS6DASTvF3HrXwwozA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.37.0",
-        "@typescript-eslint/utils": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.38.0",
+        "@typescript-eslint/utils": "5.38.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1395,9 +1395,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.0.tgz",
+      "integrity": "sha512-HHu4yMjJ7i3Cb+8NUuRCdOGu2VMkfmKyIJsOr9PfkBVYLYrtMCK/Ap50Rpov+iKpxDTfnqvDbuPLgBE5FwUNfA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1408,13 +1408,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
-      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.0.tgz",
+      "integrity": "sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/visitor-keys": "5.37.0",
+        "@typescript-eslint/types": "5.38.0",
+        "@typescript-eslint/visitor-keys": "5.38.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1435,12 +1435,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.0.tgz",
+      "integrity": "sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/types": "5.38.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1501,15 +1501,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
-      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.38.0.tgz",
+      "integrity": "sha512-6sdeYaBgk9Fh7N2unEXGz+D+som2QCQGPAf1SxrkEr+Z32gMreQ0rparXTNGRRfYUWk/JzbGdcM8NSSd6oqnTA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.37.0",
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/scope-manager": "5.38.0",
+        "@typescript-eslint/types": "5.38.0",
+        "@typescript-eslint/typescript-estree": "5.38.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1525,13 +1525,13 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
-      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.38.0.tgz",
+      "integrity": "sha512-ByhHIuNyKD9giwkkLqzezZ9y5bALW8VNY6xXcP+VxoH4JBDKjU5WNnsiD4HJdglHECdV+lyaxhvQjTUbRboiTA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/visitor-keys": "5.37.0"
+        "@typescript-eslint/types": "5.38.0",
+        "@typescript-eslint/visitor-keys": "5.38.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1542,9 +1542,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.0.tgz",
+      "integrity": "sha512-HHu4yMjJ7i3Cb+8NUuRCdOGu2VMkfmKyIJsOr9PfkBVYLYrtMCK/Ap50Rpov+iKpxDTfnqvDbuPLgBE5FwUNfA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1555,13 +1555,13 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
-      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.0.tgz",
+      "integrity": "sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/visitor-keys": "5.37.0",
+        "@typescript-eslint/types": "5.38.0",
+        "@typescript-eslint/visitor-keys": "5.38.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1582,12 +1582,12 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.0.tgz",
+      "integrity": "sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/types": "5.38.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2097,9 +2097,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001406",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
-      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
+      "version": "1.0.30001409",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
+      "integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==",
       "dev": true,
       "funding": [
         {
@@ -2423,9 +2423,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.254",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
-      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
+      "version": "1.4.257",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz",
+      "integrity": "sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2832,16 +2832,15 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz",
-      "integrity": "sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.38.0.tgz",
+      "integrity": "sha512-GgHi/GNuUbTOeoJiEANi0oI6fF3gBQc3bGFYj40nnAPCbhrtEDf2rjBmefFadweBmO1Du1YovHeDP2h5JLhtTQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.37.0",
-        "@typescript-eslint/type-utils": "5.37.0",
-        "@typescript-eslint/utils": "5.37.0",
+        "@typescript-eslint/scope-manager": "5.38.0",
+        "@typescript-eslint/type-utils": "5.38.0",
+        "@typescript-eslint/utils": "5.38.0",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
@@ -2865,14 +2864,14 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/parser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.37.0.tgz",
-      "integrity": "sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
+      "integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.37.0",
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/scope-manager": "5.38.0",
+        "@typescript-eslint/types": "5.38.0",
+        "@typescript-eslint/typescript-estree": "5.38.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2892,13 +2891,13 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
-      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.38.0.tgz",
+      "integrity": "sha512-ByhHIuNyKD9giwkkLqzezZ9y5bALW8VNY6xXcP+VxoH4JBDKjU5WNnsiD4HJdglHECdV+lyaxhvQjTUbRboiTA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/visitor-keys": "5.37.0"
+        "@typescript-eslint/types": "5.38.0",
+        "@typescript-eslint/visitor-keys": "5.38.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2909,9 +2908,9 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/types": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.0.tgz",
+      "integrity": "sha512-HHu4yMjJ7i3Cb+8NUuRCdOGu2VMkfmKyIJsOr9PfkBVYLYrtMCK/Ap50Rpov+iKpxDTfnqvDbuPLgBE5FwUNfA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2922,13 +2921,13 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
-      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.0.tgz",
+      "integrity": "sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/visitor-keys": "5.37.0",
+        "@typescript-eslint/types": "5.38.0",
+        "@typescript-eslint/visitor-keys": "5.38.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2949,12 +2948,12 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.0.tgz",
+      "integrity": "sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/types": "5.38.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -3399,9 +3398,9 @@
       }
     },
     "node_modules/fb-watchman": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
-      "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
@@ -8100,31 +8099,31 @@
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz",
-      "integrity": "sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.38.0.tgz",
+      "integrity": "sha512-iZq5USgybUcj/lfnbuelJ0j3K9dbs1I3RICAJY9NZZpDgBYXmuUlYQGzftpQA9wC8cKgtS6DASTvF3HrXwwozA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.37.0",
-        "@typescript-eslint/utils": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.38.0",
+        "@typescript-eslint/utils": "5.38.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
         "@typescript-eslint/types": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-          "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.0.tgz",
+          "integrity": "sha512-HHu4yMjJ7i3Cb+8NUuRCdOGu2VMkfmKyIJsOr9PfkBVYLYrtMCK/Ap50Rpov+iKpxDTfnqvDbuPLgBE5FwUNfA==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
-          "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.0.tgz",
+          "integrity": "sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "@typescript-eslint/visitor-keys": "5.37.0",
+            "@typescript-eslint/types": "5.38.0",
+            "@typescript-eslint/visitor-keys": "5.38.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -8133,12 +8132,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-          "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.0.tgz",
+          "integrity": "sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/types": "5.38.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -8172,43 +8171,43 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
-      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.38.0.tgz",
+      "integrity": "sha512-6sdeYaBgk9Fh7N2unEXGz+D+som2QCQGPAf1SxrkEr+Z32gMreQ0rparXTNGRRfYUWk/JzbGdcM8NSSd6oqnTA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.37.0",
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/scope-manager": "5.38.0",
+        "@typescript-eslint/types": "5.38.0",
+        "@typescript-eslint/typescript-estree": "5.38.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
-          "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.38.0.tgz",
+          "integrity": "sha512-ByhHIuNyKD9giwkkLqzezZ9y5bALW8VNY6xXcP+VxoH4JBDKjU5WNnsiD4HJdglHECdV+lyaxhvQjTUbRboiTA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "@typescript-eslint/visitor-keys": "5.37.0"
+            "@typescript-eslint/types": "5.38.0",
+            "@typescript-eslint/visitor-keys": "5.38.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-          "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.0.tgz",
+          "integrity": "sha512-HHu4yMjJ7i3Cb+8NUuRCdOGu2VMkfmKyIJsOr9PfkBVYLYrtMCK/Ap50Rpov+iKpxDTfnqvDbuPLgBE5FwUNfA==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
-          "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.0.tgz",
+          "integrity": "sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "@typescript-eslint/visitor-keys": "5.37.0",
+            "@typescript-eslint/types": "5.38.0",
+            "@typescript-eslint/visitor-keys": "5.38.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -8217,12 +8216,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-          "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.0.tgz",
+          "integrity": "sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/types": "5.38.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -8594,9 +8593,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001406",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
-      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
+      "version": "1.0.30001409",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
+      "integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==",
       "dev": true
     },
     "chalk": {
@@ -8843,9 +8842,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.254",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
-      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
+      "version": "1.4.257",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz",
+      "integrity": "sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A==",
       "dev": true
     },
     "emittery": {
@@ -9184,16 +9183,15 @@
       },
       "dependencies": {
         "@typescript-eslint/eslint-plugin": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz",
-          "integrity": "sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.38.0.tgz",
+          "integrity": "sha512-GgHi/GNuUbTOeoJiEANi0oI6fF3gBQc3bGFYj40nnAPCbhrtEDf2rjBmefFadweBmO1Du1YovHeDP2h5JLhtTQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/scope-manager": "5.37.0",
-            "@typescript-eslint/type-utils": "5.37.0",
-            "@typescript-eslint/utils": "5.37.0",
+            "@typescript-eslint/scope-manager": "5.38.0",
+            "@typescript-eslint/type-utils": "5.38.0",
+            "@typescript-eslint/utils": "5.38.0",
             "debug": "^4.3.4",
-            "functional-red-black-tree": "^1.0.1",
             "ignore": "^5.2.0",
             "regexpp": "^3.2.0",
             "semver": "^7.3.7",
@@ -9201,41 +9199,41 @@
           }
         },
         "@typescript-eslint/parser": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.37.0.tgz",
-          "integrity": "sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
+          "integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/scope-manager": "5.37.0",
-            "@typescript-eslint/types": "5.37.0",
-            "@typescript-eslint/typescript-estree": "5.37.0",
+            "@typescript-eslint/scope-manager": "5.38.0",
+            "@typescript-eslint/types": "5.38.0",
+            "@typescript-eslint/typescript-estree": "5.38.0",
             "debug": "^4.3.4"
           }
         },
         "@typescript-eslint/scope-manager": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
-          "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.38.0.tgz",
+          "integrity": "sha512-ByhHIuNyKD9giwkkLqzezZ9y5bALW8VNY6xXcP+VxoH4JBDKjU5WNnsiD4HJdglHECdV+lyaxhvQjTUbRboiTA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "@typescript-eslint/visitor-keys": "5.37.0"
+            "@typescript-eslint/types": "5.38.0",
+            "@typescript-eslint/visitor-keys": "5.38.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-          "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.0.tgz",
+          "integrity": "sha512-HHu4yMjJ7i3Cb+8NUuRCdOGu2VMkfmKyIJsOr9PfkBVYLYrtMCK/Ap50Rpov+iKpxDTfnqvDbuPLgBE5FwUNfA==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
-          "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.0.tgz",
+          "integrity": "sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "@typescript-eslint/visitor-keys": "5.37.0",
+            "@typescript-eslint/types": "5.38.0",
+            "@typescript-eslint/visitor-keys": "5.38.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -9244,12 +9242,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-          "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.0.tgz",
+          "integrity": "sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/types": "5.38.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -9551,9 +9549,9 @@
       }
     },
     "fb-watchman": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
-      "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "dev": true,
       "requires": {
         "bser": "2.1.1"


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._