### PR TITLE
chore: enable renovate with dev dependencies auto-merge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "Tradeshift/renovate-config:config-github-action",
     "Tradeshift/renovate-config:automerge-minor",
-    "Tradeshift/renovate-config:automerge-dev-deps"
+    "Tradeshift/renovate-config:automerge-dev-deps",
+    "local>Tradeshift/renovate-config:automerge-dev-deps"
   ]
 }


### PR DESCRIPTION
This PR enables renovate bot with auto-merge for dev depedencies .